### PR TITLE
Core-Fix: remove shortcut and fix commit

### DIFF
--- a/packages/core/src/dom/children/for.ts
+++ b/packages/core/src/dom/children/for.ts
@@ -41,7 +41,7 @@ export const For = <Item>(
     if (deletable.size) {
       deletable.forEach((key) => {
         const block = itemsMap.getItemByKey(key)?.value
-        block?.destroy()
+        block?.triggerDestroy()
         itemsMap.deleteByKey(key)
       })
     }

--- a/packages/core/src/dom/children/switch.ts
+++ b/packages/core/src/dom/children/switch.ts
@@ -29,7 +29,7 @@ export const Switch = <Value>(
 
     if (newValue !== currentValue) {
       currentValue = newValue
-      currentBlock?.destroy()
+      currentBlock?.triggerDestroy()
       componentContext.set(thisComponent)
       currentBlock = render(newValue)
       componentContext.set(null)

--- a/packages/core/src/dom/children/toggle.ts
+++ b/packages/core/src/dom/children/toggle.ts
@@ -29,11 +29,11 @@ export const Toggle = (
 
     if (!newValue) {
       currentValue = newValue
-      currentBlock?.destroy()
+      currentBlock?.triggerDestroy()
       currentBlock = null
     } else if (newValue !== currentValue) {
       currentValue = newValue
-      currentBlock?.destroy()
+      currentBlock?.triggerDestroy()
       componentContext.set(thisComponent)
       currentBlock = render(newValue)
       componentContext.set(null)

--- a/packages/core/src/dom/component/component.ts
+++ b/packages/core/src/dom/component/component.ts
@@ -29,9 +29,6 @@ export const component = <Props>(render: ComponentFunction<Props>) => {
     componentBlock.outletRender = outlet ?? null
 
     if (componentContext.has()) {
-      const parentComponent = componentContext.get()!
-      componentBlock.shortcutParentComponent = parentComponent
-      parentComponent.appendShortcutChildComponent(componentBlock)
       previousComponent = componentContext.get()
     }
 
@@ -46,7 +43,7 @@ export const component = <Props>(render: ComponentFunction<Props>) => {
       } as ProvideProps,
     )
 
-    componentBlock.pushChildren(renderedChild)
+    componentBlock.child = renderedChild
     renderedChild.parent = componentBlock
     componentContext.set(previousComponent)
 

--- a/packages/core/src/dom/component/componentBlock.ts
+++ b/packages/core/src/dom/component/componentBlock.ts
@@ -1,18 +1,13 @@
 import { Block } from '@dom/type.ts'
-import { isArray } from '@type/guard.ts'
 import { RVJS_COMPONENT } from '@util/symbol.ts'
-import { Element, isElement } from '../element/elementBlock.ts'
+import { isElement } from '../element/elementBlock.ts'
 
 export class Component {
   $$typeof = RVJS_COMPONENT
-  
+
   #key: string | null
-  #children: Block[]
+  #child: Block | null
   #parent: Block | null
-  #shortcut: {
-    parentComponent: Component | null
-    childComponents: Set<Component>
-  }
   #handlers: {
     onMount: Function | null
     onDestroy: Function | null
@@ -25,12 +20,8 @@ export class Component {
 
   constructor() {
     this.#key = null
-    this.#children = []
+    this.#child = null
     this.#parent = null
-    this.#shortcut = {
-      parentComponent: null,
-      childComponents: new Set(),
-    }
     this.#handlers = {
       onMount: null,
       onDestroy: null,
@@ -50,18 +41,6 @@ export class Component {
     return this.#key
   }
 
-  get children() {
-    return this.#children
-  }
-
-  pushChildren(children: Element | Component | Element[] | Component[]) {
-    if (isArray(children)) {
-      this.#children.push(...children)
-    } else {
-      this.#children.push(children)
-    }
-  }
-
   get parent() {
     return this.#parent
   }
@@ -70,27 +49,35 @@ export class Component {
     this.#parent = value
   }
 
-  set shortcutParentComponent(value: Component | null) {
-    this.#shortcut.parentComponent = value
+  get child() {
+    return this.#child as Block
   }
 
-  get shortcutParentComponent() {
-    return this.#shortcut.parentComponent
+  set child(child: Block) {
+    this.#child = child
   }
 
-  appendShortcutChildComponent(value: Component) {
-    this.#shortcut.childComponents.add(value)
-  }
+  get childElement() {
+    const child = this.#child as Block
 
-  get shortcutChildComponents() {
-    return this.#shortcut.childComponents
+    if (isElement(child)) {
+      return child.element
+    } else {
+      let element: HTMLElement | null = null
+      child.traverseChildren(child, (block) => {
+        if (isElement(block)) {
+          element = block.element
+        }
+      })
+      return element as unknown as HTMLElement
+    }
   }
 
   set onMountHandler(value: Function) {
     this.#handlers.onMount = value
   }
 
-  set onDestoryHandler(value: Function) {
+  set onDestroyHandler(value: Function) {
     this.#handlers.onDestroy = value
   }
 
@@ -115,118 +102,80 @@ export class Component {
     this.#onOutletChangeHandler = value
   }
 
-  getChildElements() {
-    return this.#children.map((child) => {
-      if (isElement(child)) {
-        return child.element
-      } else {
-        let element: HTMLElement | null = null
-        child.traverseChildren((block) => {
-          if (isElement(block)) {
-            element = block.element
-          }
-        })
-        // @ts-ignore
-        return element as HTMLElement
-      }
-    })
-  }
-
-  onCommit() {
-    this.traverseShortcutChildComponents((childComponent) => {
-      childComponent.onMount()
-    })
-  }
-
   addCleanUpHandler(handler: Function) {
     this.#handlers.cleanUps.push(handler)
   }
 
-  onMount() {
+  #commit() {
+    this.traverseChildren(this, (child) => {
+      if (isComponent(child)) {
+        child.triggerOnMount()
+      }
+    })
+  }
+
+  #onMount() {
     if (this.#handlers.onMount) {
       this.#handlers.onMount()
       this.#handlers.onMount = null
     }
   }
 
-  destroy() {
-    if (this.#isDestroyed) {
-      return
-    }
-    this.traverseChildren((child) => {
-      child.cleanUp()
-    })
-  }
-
-  selfDestroy() {
-    if (isElement(this.parent)) {
-      this.parent.deleteChild(this)
-    }
-    this.destroy()
-    this.#isDestroyed = true
-  }
-
-  cleanUp() {
+  #cleanUp() {
     if (this.#handlers.onDestroy) {
       this.#handlers.onDestroy()
     }
     this.#handlers.cleanUps.forEach((handler) => {
       handler(this)
     })
-    if (this.#shortcut.parentComponent) {
-      this.#shortcut.parentComponent.shortcutChildComponents.delete(this)
-    }
   }
 
-  // @ts-ignore
-  traverseChildren(callback: (child: Block) => void, block: Block = this) {
-    if (this.#children.length === 0) {
-      callback(block)
+  #destroy() {
+    if (this.#isDestroyed) {
       return
     }
-    this.#children.flat().forEach((child) => {
-      child.traverseChildren(callback, child)
+    this.traverseChildren(this, (child) => {
+      child.triggerCleanUp()
     })
+  }
+
+  #selfDestroy() {
+    if (isElement(this.parent)) {
+      this.parent.deleteChild(this)
+    }
+    this.triggerDestroy()
+    this.#isDestroyed = true
+  }
+
+  triggerOnMount() {
+    this.#onMount()
+  }
+
+  triggerCommit() {
+    this.#commit()
+  }
+
+  triggerCleanUp() {
+    this.#cleanUp()
+  }
+
+  triggerDestroy() {
+    this.#destroy()
+  }
+
+  triggerSelfDestroy() {
+    this.#selfDestroy()
+  }
+
+  traverseChildren(block: Block, callback: (child: Block) => void) {
     callback(block)
-  }
-
-  traverseChildrenUntilComponent(callback: (child: Component) => void) {
-    if (this.#children.length === 0) {
-      return
+    if (isComponent(block)) {
+      block.child.traverseChildren(block.child, callback)
+    } else if (isElement(block)) {
+      block.children.flat().forEach((child) => {
+        child.traverseChildren(child, callback)
+      })
     }
-    this.#children.flat().forEach((child) => {
-      if (isComponent(child)) {
-        callback(child)
-        return
-      }
-      child.traverseChildrenUntilComponent(callback)
-    })
-  }
-
-  traverseShortcutChildComponents(callback: (child: Component) => void) {
-    callback(this)
-    this.#shortcut.childComponents.forEach((child) => {
-      child.traverseShortcutChildComponents(callback)
-    })
-  }
-
-  traverseShortcutParentComponent(
-    callback: (parent: Component) => boolean | undefined,
-  ) {
-    if (this.#shortcut.parentComponent) {
-      const isStop = callback(this.#shortcut.parentComponent) ?? false
-      if (!isStop) {
-        this.#shortcut.parentComponent.traverseShortcutParentComponent(callback)
-      }
-    }
-  }
-
-  static isComponent(value: unknown): value is Component {
-    if (!value) {
-      return false
-    }
-
-    return value instanceof Component
   }
 }
 

--- a/packages/core/src/dom/component/root.ts
+++ b/packages/core/src/dom/component/root.ts
@@ -1,28 +1,15 @@
 import { componentContext } from '@context/executionContext.ts'
-import { Children } from '@dom/type.ts'
-import { Element, isElement } from '../element/elementBlock.ts'
-import { Component, isComponent } from './componentBlock.ts'
+import { Child } from '@dom/type.ts'
+import { Element } from '../element/elementBlock.ts'
+import { Component } from './componentBlock.ts'
 
-interface RootProperties {
-  children: Children
-}
-
-export const root = (
-  element: HTMLElement,
-  propertiesFn: () => RootProperties,
-) => {
+export const root = (element: HTMLElement, child: Child) => {
   const rootComponent = new Component()
   const rootElement = new Element({ element })
   rootComponent.key = 'root'
 
   componentContext.set(rootComponent)
-  const { children } = propertiesFn()
-  rootElement.appendChildren(children)
-  children.forEach((childBlock) => {
-    if (isComponent(childBlock) || isElement(childBlock)) {
-      childBlock.onCommit()
-    }
-  })
-  rootComponent.pushChildren(rootElement)
+  rootElement.appendChildren([child])
+  rootElement.triggerCommit()
   componentContext.set(null)
 }

--- a/packages/core/src/reactive/lifecycle/onDestroy.ts
+++ b/packages/core/src/reactive/lifecycle/onDestroy.ts
@@ -3,5 +3,5 @@ import { componentContext } from '@context/executionContext.ts'
 export const onDestroy = (callback: () => void) => {
   const component = componentContext.get()!
 
-  component.onDestoryHandler = callback
+  component.onDestroyHandler = callback
 }


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [x] Refactoring
- [ ] Documentation Update
- [ ] Other

## Description
The component shortcut feature is fast, but it's complicated to use, and it has a high probability of throwing errors.

## Changes Made
I removed the component shortcut feature and instead modified it to traverse all elements when a specific element is committed to the DOM.
