### PR TITLE
core-fix: fix update DOM algorithm

### DIFF
--- a/packages/core/src/dom/element/elementBlock.ts
+++ b/packages/core/src/dom/element/elementBlock.ts
@@ -214,7 +214,25 @@ export class Element {
   }
 
   #updateDOM(elements: (HTMLElement | HTMLElement[])[]) {
-    this.#element.replaceChildren(...elements.flat())
+    const existElementsSet = new Set<HTMLElement>()
+
+    for (const child of this.#element.children) {
+      existElementsSet.add(child as HTMLElement)
+    }
+
+    for (const newElement of elements.flat()) {
+      const existElement = existElementsSet.has(newElement)
+
+      if (existElement) {
+        existElementsSet.delete(newElement)
+      } else {
+        this.#element.appendChild(newElement)
+      }
+    }
+
+    existElementsSet.forEach((element) => {
+      this.#element.removeChild(element)
+    })
   }
 
   appendStateUnsubscribeHandler(unsubscribeHandler: Observer['unsubscribe']) {


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [X] Bug Fix
- [ ] Refactoring
- [ ] Documentation Update
- [ ] Other

## Description
The ```replaceChildren``` method was re-appending elements that already existed, rather than leaving them alone. This resulted in properties like ```transition``` not working properly.

## Changes Made
Added direct comparison behavior instead of ```replaceChildren``` method
