### PR TITLE
Core-Fix: Fix copying SVG elements

### DIFF
--- a/packages/core/src/dom/element/element.ts
+++ b/packages/core/src/dom/element/element.ts
@@ -43,7 +43,7 @@ const createSvgElement = (
 
   Object.entries(attributes).forEach(([key, value]) => {
     if (key === 'className') {
-      svgElement.classList.add(value as string)
+      elementBlock.element.classList.add(value as string)
     } else {
       setProperty(elementBlock, key, value)
     }


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [X] Bug Fix
- [ ] Refactoring
- [ ] Documentation Update
- [ ] Other

## Description
Fix code that add a class to the wrong element.

## Changes Made
Modify to add the class to the copied svg element.
