### PR TITLE
Core-Fix: Modify class to use state

### DIFF
--- a/packages/core/src/type/guard.ts
+++ b/packages/core/src/type/guard.ts
@@ -5,3 +5,7 @@ export const isArray = (value: unknown): value is unknown[] => {
 export const isFunction = (value: unknown): value is Function => {
   return typeof value === 'function'
 }
+
+export const isString = (value: unknown): value is string => {
+  return typeof value === 'string'
+}


### PR DESCRIPTION
## Type of Change
- [X] New Feature
- [X] Bug Fix
- [ ] Refactoring
- [ ] Documentation Update
- [ ] Other

## Description
Previously, the only way to add a class was to add it as a string to the className. So I added a new syntax for changing the class based on state.

## Changes Made
Using ```classes``` property
``` javascript
const App = () => {
  const [getTextType, setTextType] = useState<'primary' | 'secondary'>('primary')

  return div({
    children: [
      button({
        textContent: dynamic(() => getTextType() === 'primary' ? 'make secondary' : 'make primary'),
        onclick: () => setTextType(getTextType() === 'primary' ? 'secondary' : 'primary'),
      }),
      p({
        textContent: 'Hello World',
        classes: [
          style.base,
          dynamic(() => getTextType() === 'primary' ? style.weightBold : style.weightRegular),
          dynamic(() => getTextType() === 'primary' ? style.colorBlack : style.colorGray),
        ],
      }),
    ],
  })
}
```

