### PR TITLE
Core-Fix: Change updateDOM algorithm

### DIFF
--- a/packages/core/src/util/dom.ts
+++ b/packages/core/src/util/dom.ts
@@ -1,0 +1,11 @@
+export const insertChildrenAtIndex = (
+  parentElement: HTMLElement,
+  index: number,
+  newChildren: HTMLElement[],
+) => {
+  const referenceNode = parentElement.children[index]
+
+  newChildren.forEach((child) => {
+    parentElement.insertBefore(child, referenceNode)
+  })
+}


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [X] Bug Fix
- [ ] Refactoring
- [ ] Documentation Update
- [ ] Other

## Description
Fixed re-registering unrelated sibling elements in the DOM when changing dynamic elements using the render function.

## Changes Made
Modified to only update elements created using the render function.
