### PR TITLE
Core-Fix: Fixed useEffect

### DIFF
--- a/packages/core/src/reactive/hook/useEffect.ts
+++ b/packages/core/src/reactive/hook/useEffect.ts
@@ -1,22 +1,21 @@
-import {
-  componentContext,
-  subscribeStateContext,
-} from '@context/executionContext.ts'
-import { GetState } from '@hook/useState.ts'
+import { subscribeStateContext } from '@context/executionContext.ts'
+import { GetState, isGetState } from '@hook/useState.ts'
 
-export const useEffect = (callback: () => void, dependencies: GetState[]) => {
-  const componentBlock = componentContext.get()
-
-  if (componentBlock) {
-    dependencies.forEach((dependency) => {
+export const useEffect = (
+  callback: () => void,
+  dependencies: (GetState | any)[],
+) => {
+  dependencies.forEach((dependency) => {
+    if (isGetState(dependency)) {
       subscribeStateContext.set({
-        block: componentBlock,
+        // @ts-ignore
+        block: null,
         type: 'useEffect',
         property: 'useEffect',
         value: callback,
       })
       dependency()
       subscribeStateContext.set(null)
-    })
-  }
+    }
+  })
 }


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [X] Bug Fix
- [ ] Refactoring
- [ ] Documentation Update
- [ ] Other

## Description
Fixed a rule that enforced the use of useEffect only inside components.

## Changes Made
You can use useEffect even if you don't use components.
