### PR TITLE
Core-Fix: Split class strings with spaces

### DIFF
--- a/packages/core/src/dom/element/property.ts
+++ b/packages/core/src/dom/element/property.ts
@@ -106,7 +106,9 @@ const customProperties = {
         parent.element.classList.add(cls())
         subscribeStateContext.set(null)
       } else if (isString(cls)) {
-        parent.element.classList.add(cls)
+        cls.split(' ').forEach((cls) => {
+          parent.element.classList.add(cls)
+        })
       }
     })
   },


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactoring
- [ ] Documentation Update
- [ ] Other

## Description
When using a function like recipe in vanilla extract css, it returns multiple classes as a single string, including spaces. I added code to handle this.
