### PR TITLE
UI-Fix: Modify to accept text nodes

### DIFF
--- a/packages/ui/src/component/content/list/listItem/ListItem.css.ts
+++ b/packages/ui/src/component/content/list/listItem/ListItem.css.ts
@@ -2,6 +2,9 @@ import vars from '@theme/variable/vars.css.ts'
 import { style } from '@vanilla-extract/css'
 
 export const listItem_li_style = style({
+  marginTop: vars.spacing['03'],
+  marginBottom: vars.spacing['03'],
+  color: vars.color.textPrimary,
   '::marker': {
     fontFamily: 'IBM Plex Sans, sans-serif',
     fontStyle: 'normal',

--- a/packages/ui/src/component/content/list/listItem/ListItem.props.ts
+++ b/packages/ui/src/component/content/list/listItem/ListItem.props.ts
@@ -3,12 +3,12 @@ import { Prop, prop } from '@rvjs/core/reactive'
 import { isChildren, isOptional, isProp, isString } from '@rvjs/is'
 
 export interface ListItemProps {
-  text: Prop<string>
+  text?: Prop<string>
   children?: Children
 }
 
 export const listItemPropsType = {
-  text: isProp(isString),
+  text: isOptional(isProp(isString)),
   children: isOptional(isChildren),
 }
 

--- a/packages/ui/src/component/content/list/listItem/ListItem.ts
+++ b/packages/ui/src/component/content/list/listItem/ListItem.ts
@@ -9,21 +9,28 @@ import {
 import { li } from '@rvjs/core/dom'
 import { dynamic, prop } from '@rvjs/core/reactive'
 import { checkProps } from '@rvjs/is'
+import { text_recipe } from '@typography/text/Text.css.ts'
 import Text from '@typography/text/Text.ts'
+import { ifIs } from '@util/array.ts'
 
 const ListItem = (props: ListItemProps) => {
   const { text, children = [] } = checkProps(props, listItemPropsType)
 
   return li({
-    classes: [dynamic(() => listItem_li_style)],
+    classes: [
+      listItem_li_style,
+      dynamic(() => text_recipe({ kind: 'body-01' })),
+    ],
     children: [
-      Text({
-        text,
-        as: 'span',
-        kind: prop(() => 'body-01'),
-        color: prop(() => 'textPrimary'),
-        classes: [prop(() => listItem_text_style)],
-      }),
+      ...ifIs(!!text, () =>
+        Text({
+          text,
+          as: 'span',
+          kind: prop(() => 'body-01'),
+          color: prop(() => 'textPrimary'),
+          classes: [prop(() => listItem_text_style)],
+        }),
+      ),
       ...children,
     ],
   })

--- a/packages/ui/src/component/typography/link/Link.css.ts
+++ b/packages/ui/src/component/typography/link/Link.css.ts
@@ -40,7 +40,7 @@ export const link_anchor_recipe = recipe({
   },
 })
 
-export const link_text_style = recipe({
+export const link_text_recipe = recipe({
   base: {
     color: `${vars.color.linkPrimary} !important`,
     selectors: {

--- a/packages/ui/src/component/typography/link/Link.props.ts
+++ b/packages/ui/src/component/typography/link/Link.props.ts
@@ -1,14 +1,22 @@
-import { ElementType } from '@rvjs/core/dom'
+import { Children, Element, ElementType, svg } from '@rvjs/core/dom'
 import { prop, Prop } from '@rvjs/core/reactive'
-import { isAny, isBoolean, isOptional, isProp, isString } from '@rvjs/is'
+import {
+  isBoolean,
+  isChild,
+  isChildren,
+  isOptional,
+  isProp,
+  isString,
+} from '@rvjs/is'
 
 export interface LinkProps {
   href: Prop<string>
   as?: ElementType
-  text: Prop<string>
+  text?: Prop<string>
+  children?: Children
   disabled?: Prop<boolean>
   inline?: Prop<boolean>
-  renderIcon?: SVGElement
+  renderIcon?: Element
   size?: Prop<'sm' | 'md' | 'lg'>
 }
 
@@ -16,9 +24,10 @@ export const linkPropsType = {
   href: isProp(isString),
   as: isOptional(isString),
   text: isProp(isString),
+  children: isOptional(isChildren),
   disabled: isOptional(isProp(isBoolean)),
   inline: isOptional(isProp(isBoolean)),
-  renderIcon: isOptional(isAny),
+  renderIcon: isOptional(isChild),
   size: isOptional(isProp(isString)),
 }
 
@@ -26,8 +35,9 @@ export const linkRenderProps = {
   href: (p: string) => prop(() => p),
   as: (p: ElementType) => p,
   text: (p: string) => prop(() => p),
+  children: (p: Children) => p,
   disabled: (p: boolean) => prop(() => p),
   inline: (p: boolean) => prop(() => p),
-  renderIcon: (p: SVGElement) => p,
+  renderIcon: (p: SVGElement) => svg(p),
   size: (p: string) => prop(() => p),
 }

--- a/packages/ui/src/component/typography/link/Link.ts
+++ b/packages/ui/src/component/typography/link/Link.ts
@@ -1,11 +1,11 @@
-import { a, svg } from '@rvjs/core/dom'
+import { a, overrideElement } from '@rvjs/core/dom'
 import { dynamic, prop, useState } from '@rvjs/core/reactive'
 import { useNavigate } from '@rvjs/core/router'
 import { checkProps } from '@rvjs/is'
 import {
   link_anchor_recipe,
   link_icon_recipe,
-  link_text_style,
+  link_text_recipe,
 } from '@typography/link/Link.css.ts'
 import { LinkProps, linkPropsType } from '@typography/link/Link.props.ts'
 import Text from '@typography/text/Text.ts'
@@ -16,6 +16,7 @@ const Link = (props: LinkProps) => {
     href,
     as = 'p',
     text,
+    children = [],
     disabled = prop(() => false),
     inline = prop(() => false),
     renderIcon,
@@ -33,25 +34,28 @@ const Link = (props: LinkProps) => {
       setVisited(true)
     },
     children: [
-      Text({
-        as,
-        text,
-        kind: prop(() =>
-          size() === 'sm'
-            ? 'helper-text-01'
-            : size() === 'md'
-              ? 'body-compact-01'
-              : 'body-compact-02',
-        ),
-        color: prop(() => 'linkPrimary'),
-        classes: [
-          prop(() =>
-            link_text_style({ disabled: disabled(), visited: visited() }),
+      ...ifIs(!!text, () =>
+        Text({
+          as,
+          text,
+          kind: prop(() =>
+            size() === 'sm'
+              ? 'helper-text-01'
+              : size() === 'md'
+                ? 'body-compact-01'
+                : 'body-compact-02',
           ),
-        ],
-      }),
+          color: prop(() => 'linkPrimary'),
+          classes: [
+            prop(() =>
+              link_text_recipe({ disabled: disabled(), visited: visited() }),
+            ),
+          ],
+        }),
+      ),
+      ...children,
       ...ifIs(!!renderIcon, () => {
-        return svg(renderIcon!, {
+        return overrideElement(renderIcon!, {
           classes: [
             dynamic(() =>
               link_icon_recipe({

--- a/packages/ui/src/component/typography/text/Text.props.ts
+++ b/packages/ui/src/component/typography/text/Text.props.ts
@@ -1,18 +1,20 @@
-import { ElementType } from '@rvjs/core/dom'
+import { Children, ElementType } from '@rvjs/core/dom'
 import { Prop, prop } from '@rvjs/core/reactive'
-import { isArray, isOptional, isProp, isString } from '@rvjs/is'
+import { isArray, isChildren, isOptional, isProp, isString } from '@rvjs/is'
 import { TextStyleProps } from '@typography/text/Text.css.ts'
 
 export interface TextProps extends TextStyleProps {
   as?: ElementType
   classes?: Prop<string>[]
-  text: Prop<string>
+  text?: Prop<string>
+  children?: Children
 }
 
 export const textPropsType = {
   as: isOptional(isString),
   classes: isOptional(isArray(isProp(isString))),
-  text: isProp(isString),
+  text: isOptional(isProp(isString)),
+  children: isChildren,
   kind: isOptional(isProp(isString)),
   color: isOptional(isProp(isString)),
 }
@@ -21,6 +23,7 @@ export const textRenderProps = {
   as: (p: ElementType) => p,
   classes: (p: string[]) => p.map((cls) => prop(() => cls)),
   text: (p: string) => prop(() => p),
+  children: (p: Children) => p,
   kind: (p: TextStyleProps['kind']) => prop(() => p),
   color: (p: TextStyleProps['color']) => prop(() => p),
 }

--- a/packages/ui/src/component/typography/text/Text.ts
+++ b/packages/ui/src/component/typography/text/Text.ts
@@ -3,12 +3,14 @@ import { dynamic, prop } from '@rvjs/core/reactive'
 import { checkProps } from '@rvjs/is'
 import { text_recipe, textSprinkles } from '@typography/text/Text.css.ts'
 import { TextProps, textPropsType } from '@typography/text/Text.props.ts'
+import { ifIs } from '@util/array.ts'
 
 const Text = (props: TextProps) => {
   const {
     as = 'p',
     classes = [],
     text,
+    children,
     kind = prop(() => 'body-01'),
     color = prop(() => 'textPrimary'),
   } = checkProps<TextProps>(props, textPropsType)
@@ -19,7 +21,12 @@ const Text = (props: TextProps) => {
       dynamic(() => textSprinkles({ color: color() })),
       ...classes.map((cls) => dynamic(() => cls())),
     ],
-    textContent: dynamic(() => text()),
+    ...ifIs(!!text, () => ({
+      textContent: dynamic(() => text!()),
+    }))[0],
+    ...ifIs(!!children, () => ({
+      children: children,
+    }))[0],
   })
 }
 


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [X] Bug Fix
- [ ] Refactoring
- [ ] Documentation Update
- [ ] Other

## Description
I modified the props to allow passing text nodes to the text property, which previously only accepted strings.