### PR TITLE
Core-Fix: Implement lazy render component

### DIFF
--- a/packages/core/src/dom/block/block.ts
+++ b/packages/core/src/dom/block/block.ts
@@ -69,6 +69,9 @@ export class Block extends RouteContext(
   #commit() {
     this.traverseChildren(this, (child) => {
       if (isComponent(child)) {
+        if (!child.isRendered()) {
+          child.triggerLazyRender()
+        }
         child.triggerOnMount()
       }
       return true

--- a/packages/core/src/dom/block/component.ts
+++ b/packages/core/src/dom/block/component.ts
@@ -1,15 +1,28 @@
 import { Block } from '@block/block.ts'
 import { LifecycleHandlers } from '@block/util/lifecycleHandlers.ts'
 import { RouteContext } from '@block/util/routeContext.ts'
-import { HTMLNode } from '@element/type.ts'
-import { isElement, isTextNode } from '@type/rvjs.ts'
+import { componentContext } from '@context/executionContext.ts'
+import { isComponent, isElement, isTextNode } from '@type/rvjs.ts'
 
 export class ComponentBlock extends RouteContext(LifecycleHandlers(Block)) {
   #key: string | null
+  #lazyRenderContext: {
+    tempElement: Comment
+    isRendered: boolean
+    renderFn: Function
+    previousComponent: Block
+  }
 
   constructor() {
     super({ type: 'COMPONENT' })
     this.#key = null
+    this.#lazyRenderContext = {
+      tempElement: null,
+      isRendered: false,
+      renderFn: null,
+      previousComponent: null,
+    }
+    this.#initialRender()
   }
 
   set key(value: string | null) {
@@ -20,19 +33,50 @@ export class ComponentBlock extends RouteContext(LifecycleHandlers(Block)) {
     return this.#key
   }
 
-  appendChild(child: Block) {
+  set renderFn(renderFn: Function) {
+    this.#lazyRenderContext.renderFn = renderFn
+  }
+
+  get tempElement() {
+    return this.#lazyRenderContext.tempElement
+  }
+
+  #initialRender() {
+    const comment = document.createComment('lazy-component')
+    this.#lazyRenderContext.tempElement = comment
+    this.nodes = [comment]
+  }
+
+  triggerLazyRender() {
+    componentContext.set(this)
+    const renderedChild = this.#lazyRenderContext.renderFn()
+    this.#lazyRenderContext.renderFn = null
+    this.#lazyRenderContext.isRendered = true
+    if (isComponent(this.#lazyRenderContext.previousComponent)) {
+      componentContext.set(this.#lazyRenderContext.previousComponent)
+    }
+    this.#swapNodesForLazyRender(renderedChild)
+  }
+
+  isRendered() {
+    return this.#lazyRenderContext.isRendered
+  }
+
+  #swapNodesForLazyRender(child: Block) {
     this.child = child
     this.domLength = child.domLength
     child.parent = this
-    const newNodes: HTMLNode[] = []
     const rerenderableContexts = []
-    if (isElement(child) || isTextNode(child)) {
-      newNodes.push(child.element)
-    } else {
-      newNodes.push(...child.nodes)
+    if (!(isElement(child) || isTextNode(child))) {
       rerenderableContexts.push({ block: child, localDOMIndex: 0 })
     }
-    this.nodes = newNodes
     this.rerenderableContexts = rerenderableContexts
+    const fragment = document.createDocumentFragment()
+    if (isElement(child) || isTextNode(child)) {
+      fragment.append(child.element)
+    } else {
+      fragment.append(...child.nodes)
+    }
+    this.tempElement.replaceWith(fragment)
   }
 }

--- a/packages/core/src/dom/component/component.ts
+++ b/packages/core/src/dom/component/component.ts
@@ -27,8 +27,9 @@ export const component = <Props>(render: (props: Props) => Block) => {
         componentBlock.pathParam = { key: dynamicKey, value: pathname }
       }
     }
-    const renderedChild = render(restProps as Props & Partial<ReceivableProps>)
-    componentBlock.appendChild(renderedChild)
+    componentBlock.renderFn = () => {
+      return render(restProps as Props & Partial<ReceivableProps>)
+    }
     componentContext.set(previousComponent)
     return componentBlock
   }

--- a/packages/core/src/dom/element/type.ts
+++ b/packages/core/src/dom/element/type.ts
@@ -40,4 +40,4 @@ type FilteredSvgElementProps = FilterProps<SVGElement>
 
 type FilterProps<Props> = Omit<Props, 'style' | 'children' | 'className'>
 
-export type HTMLNode = HTMLElement | SVGElement | Text
+export type HTMLNode = HTMLElement | SVGElement | Text | Comment


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [X] Bug Fix
- [X] Refactoring
- [ ] Documentation Update
- [ ] Other

## Description
I have refactored the component rendering logic to follow a top-to-bottom rendering order, starting from the root of the component tree and progressing downwards to the leaf nodes. Previously, the components were rendered in a bottom-up sequence, beginning with the leaf nodes and moving upwards.

## Changes Made
Changed the component rendering flow from a bottom-up sequence (starting from leaf nodes) to a top-down sequence (starting from the root node).
